### PR TITLE
[BUGFIX] update include_misc/src_fileutils/save_study_results.m

### DIFF
--- a/include_misc/src_fileutils/save_study_results.m
+++ b/include_misc/src_fileutils/save_study_results.m
@@ -15,7 +15,7 @@ function save_study_results(study_info, res, default_dir)
         disp('Save canceled by user.');
     else
         fullpath = fullfile(pathname, filename);
-        save(fullpath, 'res');
+        save(fullpath, 'res', '-v7.3');
         fprintf('Saved variables to: %s\n', fullpath);
     end
 end


### PR DESCRIPTION
Used to call uiputfile with a 'Folder' argument which is not supported. Switched to using fullfile to specify default save path if specified. 